### PR TITLE
Update CODEOWNERS to new Microsoft Team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,4 +5,4 @@
 # Lines starting with '#' are comments.
 
 # These owners will be the default owners for everything in the repo.
-*       @azure/health-data-services-sdk-admins
+*       @microsoft/health-data-services-sdk-admins


### PR DESCRIPTION
## Description
The codeowners was pointed to an old team. Updating to point to the new team.